### PR TITLE
Feature/receivers in property lambdas

### DIFF
--- a/API_DIFFERENCES.md
+++ b/API_DIFFERENCES.md
@@ -24,7 +24,7 @@ This happens because in this way you are modifying the local copy of `position`,
 ```kotlin
     override fun _ready() {
         position { 
-            it.x = 5.0
+            x = 5.0
         }
     }
 ```
@@ -32,9 +32,9 @@ This happens because in this way you are modifying the local copy of `position`,
 Which is the same as:
 ```kotlin
     override fun _ready() {
-        val it = position
-        it.x = 5.0
-        position = it
+        val tmp = position
+        tmp.x = 5.0
+        position = tmp
     }
 ```
 

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/catchBall/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/catchBall/Player.kt
@@ -24,11 +24,11 @@ class Player: KinematicBody() {
 
             if(translation.x + velocity.x * delta < 4.0 &&
                     translation.x + velocity.x * delta > -4.0)
-                translation { it.x += velocity.x * delta }
+                translation { x += velocity.x * delta }
 
             if (translation.z + velocity.z * delta < 4.0 &&
                     translation.z + velocity.z * delta > -4.0)
-                translation { it.z += velocity.z * delta }
+                translation { z += velocity.z * delta }
         }
     }
 }

--- a/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
+++ b/samples/games/kotlin/src/main/kotlin/godot/samples/games/dodge/Player.kt
@@ -47,23 +47,23 @@ class Player: Area2D() {
 
         if (position.x < 0) {
             position {
-                it.x = 0.0
+                x = 0.0
             }
         }
         else if (position.x > screensize.x) {
             position {
-                it.x = screensize.x
+                x = screensize.x
             }
         }
 
         if (position.y < 0) {
             position {
-                it.y = 0.0
+                y = 0.0
             }
         }
         else if (position.y > screensize.y) {
             position {
-                it.y = screensize.y
+                y = screensize.y
             }
         }
 

--- a/tools/api-classes-generator/src/main/kotlin/Class.kt
+++ b/tools/api-classes-generator/src/main/kotlin/Class.kt
@@ -231,7 +231,7 @@ class Class(
                                     ParameterSpec.builder(
                                             "schedule",
                                             LambdaTypeName.get(
-                                                    parameters = *arrayOf(parameterTypeName),
+                                                    receiver = parameterTypeName,
                                                     returnType = ClassName("kotlin", "Unit")
                                             )
                                     ).build()


### PR DESCRIPTION
Note that the base branch is `feature/update-to-godot-3.2`

Fixes #18 

Changes the generation of property accessor dsl interface to use receivers instead of a lambda argument.

So `translation { it.x = 1.0 }` becomes `translation { x = 1.0 }` and so forth.